### PR TITLE
Escape sequences can now be set to a custom value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Ansispan.convert(ansi_text)
 # => * <span style="color: yellow">8fb4737</span><span style="color: yellow"> (</span><span style="font-weight: bold; color: cyan">HEAD -> </span><span style="font-weight: bold; color: green">master</span><span style="color: yellow">, </span><span style="font-weight: bold; color: red">origin/master</span><span style="color: yellow">, </span><span style="font-weight: bold; color: red">origin/HEAD</span><span style="color: yellow">)</span> rails new
 ```
 
+The default escape sequence is `\033` but you can override it by setting `Ansispan.escape_sequence` to your desired value.
+
+```rb
+Ansispan.escape_sequence = "\e"
+```
+
 ---
 
 ### Terminal output

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Ansispan.convert(ansi_text)
 # => * <span style="color: yellow">8fb4737</span><span style="color: yellow"> (</span><span style="font-weight: bold; color: cyan">HEAD -> </span><span style="font-weight: bold; color: green">master</span><span style="color: yellow">, </span><span style="font-weight: bold; color: red">origin/master</span><span style="color: yellow">, </span><span style="font-weight: bold; color: red">origin/HEAD</span><span style="color: yellow">)</span> rails new
 ```
 
-The default escape sequence is `\033` but you can override it by setting `Ansispan.escape_sequence` to your desired value.
+The default escape character is `\033` but you can pass your own to the convert method.
 
 ```rb
-Ansispan.escape_sequence = "\e"
+Ansispan.convert(ansi_text, escape_character: "\e")
 ```
 
 ---

--- a/lib/ansispan.rb
+++ b/lib/ansispan.rb
@@ -1,14 +1,4 @@
 class Ansispan
-  @@escape_sequence = '\033'
-
-  def self.escape_sequence
-    @@escape_sequence
-  end
-
-  def self.escape_sequence=(custom_escape_sequence)
-    @@escape_sequence = Regexp.escape(custom_escape_sequence)
-  end
-
   @foreground_colors = {
     '30': 'black',
     '31': 'red',
@@ -20,43 +10,45 @@ class Ansispan
     '37': 'white'
   }
 
-  def self.convert(str)
+  def self.convert(str, escape_character: '\033')
+    escape_character = Regexp.escape(escape_character)
+
     @foreground_colors.keys.each do |ansi|
       span = '<span style="color: ' + @foreground_colors[ansi] + '">'
       #
       # `\033[Xm` == `\033[0;Xm` sets foreground color to `X`.
       #
   
-      str = str.gsub(/#{@@escape_sequence}\[#{ansi}m/, span)
-        .gsub(/#{@@escape_sequence}\[#{ansi}m/, span)
+      str = str.gsub(/#{escape_character}\[#{ansi}m/, span)
+        .gsub(/#{escape_character}\[#{ansi}m/, span)
     end
 
     #
     # `\033[1m` enables bold font, `\033[22m` disables it
     #
-    str = str.gsub(/#{@@escape_sequence}\[1m/, '<b>')
-      .gsub(/#{@@escape_sequence}\[22m/, '</b>')
+    str = str.gsub(/#{escape_character}\[1m/, '<b>')
+      .gsub(/#{escape_character}\[22m/, '</b>')
   
 
     # Bold colors
     @foreground_colors.keys.each do |ansi|
       span = '<span style="font-weight: bold; color: ' + @foreground_colors[ansi] + '">'
-      str = str.gsub(/#{@@escape_sequence}\[1;#{ansi}m/, span)
+      str = str.gsub(/#{escape_character}\[1;#{ansi}m/, span)
     end
 
     # Underline colors
     @foreground_colors.keys.each do |ansi|
       span = '<span style="text-decoration: underline; color: ' + @foreground_colors[ansi] + '">'
-      str = str.gsub(/#{@@escape_sequence}\[4;#{ansi}m/, span)
+      str = str.gsub(/#{escape_character}\[4;#{ansi}m/, span)
     end
     #
     # `\033[3m` enables italics font, `\033[23m` disables it
     #
-    str = str.gsub(/#{@@escape_sequence}\[3m/, '<i>')
-      .gsub(/#{@@escape_sequence}\[23m/, '</i>')
+    str = str.gsub(/#{escape_character}\[3m/, '<i>')
+      .gsub(/#{escape_character}\[23m/, '</i>')
   
-    str = str.gsub(/#{@@escape_sequence}\[m/, '</span>');
-    str = str.gsub(/#{@@escape_sequence}\[0m/, '</span>');
-    return str.gsub(/#{@@escape_sequence}\[39m/, '</span>');
+    str = str.gsub(/#{escape_character}\[m/, '</span>');
+    str = str.gsub(/#{escape_character}\[0m/, '</span>');
+    return str.gsub(/#{escape_character}\[39m/, '</span>');
   end
 end

--- a/lib/ansispan.rb
+++ b/lib/ansispan.rb
@@ -1,4 +1,14 @@
 class Ansispan
+  @@escape_sequence = '\033'
+
+  def self.escape_sequence
+    @@escape_sequence
+  end
+
+  def self.escape_sequence=(custom_escape_sequence)
+    @@escape_sequence = custom_escape_sequence
+  end
+
   @foreground_colors = {
     '30': 'black',
     '31': 'red',
@@ -17,36 +27,36 @@ class Ansispan
       # `\033[Xm` == `\033[0;Xm` sets foreground color to `X`.
       #
   
-      str = str.gsub(/\033\[#{ansi}m/, span)
-        .gsub(/\033\[#{ansi}m/, span)
+      str = str.gsub(/#{@@escape_sequence}\[#{ansi}m/, span)
+        .gsub(/#{@@escape_sequence}\[#{ansi}m/, span)
     end
 
     #
     # `\033[1m` enables bold font, `\033[22m` disables it
     #
-    str = str.gsub(/\033\[1m/, '<b>')
-      .gsub(/\033\[22m/, '</b>')
+    str = str.gsub(/#{@@escape_sequence}\[1m/, '<b>')
+      .gsub(/#{@@escape_sequence}\[22m/, '</b>')
   
 
     # Bold colors
     @foreground_colors.keys.each do |ansi|
       span = '<span style="font-weight: bold; color: ' + @foreground_colors[ansi] + '">'
-      str = str.gsub(/\033\[1;#{ansi}m/, span)
+      str = str.gsub(/#{@@escape_sequence}\[1;#{ansi}m/, span)
     end
 
     # Underline colors
     @foreground_colors.keys.each do |ansi|
       span = '<span style="text-decoration: underline; color: ' + @foreground_colors[ansi] + '">'
-      str = str.gsub(/\033\[4;#{ansi}m/, span)
+      str = str.gsub(/#{@@escape_sequence}\[4;#{ansi}m/, span)
     end
     #
     # `\033[3m` enables italics font, `\033[23m` disables it
     #
-    str = str.gsub(/\033\[3m/, '<i>')
-      .gsub(/\033\[23m/, '</i>')
+    str = str.gsub(/#{@@escape_sequence}\[3m/, '<i>')
+      .gsub(/#{@@escape_sequence}\[23m/, '</i>')
   
-    str = str.gsub(/\033\[m/, '</span>');
-    str = str.gsub(/\033\[0m/, '</span>');
-    return str.gsub(/\033\[39m/, '</span>');
+    str = str.gsub(/#{@@escape_sequence}\[m/, '</span>');
+    str = str.gsub(/#{@@escape_sequence}\[0m/, '</span>');
+    return str.gsub(/#{@@escape_sequence}\[39m/, '</span>');
   end
 end

--- a/lib/ansispan.rb
+++ b/lib/ansispan.rb
@@ -6,7 +6,7 @@ class Ansispan
   end
 
   def self.escape_sequence=(custom_escape_sequence)
-    @@escape_sequence = custom_escape_sequence
+    @@escape_sequence = Regexp.escape(custom_escape_sequence)
   end
 
   @foreground_colors = {


### PR DESCRIPTION
While most ANSI color coding uses the `\033` escape sequence, some consoles might set a custom value. This PR introduces `Ansispan.escape_sequence` which can be set to any custom value.

Example:
```
irb(main):001:0" content = "\\u001b[31mF\\u001b[0m
irb(main):002:0" 
irb(main):003:0" Failures:
irb(main):004:0" 
irb(main):005:0"   1) addition adds two numbers
irb(main):006:0"      \\u001b[31mFailure/Error: describe 'addition' do   it 'adds two numbers' do     expect(add(2, 3)).to eq(7)   end end\\u001b[0m
irb(main):007:0"      \\u001b[31m\\u001b[0m
irb(main):008:0"      \\u001b[31m  expected: 7\\u001b[0m
irb(main):009:0"      \\u001b[31m       got: 5\\u001b[0m
irb(main):010:0"      \\u001b[31m\\u001b[0m
irb(main):011:0"      \\u001b[31m  (compared using ==)\\u001b[0m
irb(main):012:0"      \\u001b[36m# /tmp/test.rb:11:in `block (2 levels) in <main>'\\u001b[0m
irb(main):013:0" 
irb(main):014:0" Finished in 0.00711 seconds (files took 0.04915 seconds to load)
irb(main):015:0" \\u001b[31m1 example, 1 failure\\u001b[0m
irb(main):016:0" 
irb(main):017:0" Failed examples:
irb(main):018:0" 
irb(main):019:0" \\u001b[31mrspec /tmp/test.rb:11\\u001b[0m \\u001b[36m# addition adds two numbers\\u001b[0m"
=> "\\u001b[31mF\\u001b[0m\n\nFailures:\n\n  1) addition adds two numbers\n     \\u001b[31mFailure/Error: describe 'addition' do   it 'adds two numbers' do     expect(add(2,...
irb(main):020:0> Ansispan.escape_sequence = "\\u001b"
=> "\\u001b"
irb(main):021:0> Ansispan.convert(content)
=> "<span style=\"color: red\">F</span>\n\nFailures:\n\n  1) addition adds two numbers\n     <span style=\"color: red\">Failure/Error: describe 'addition' do   it 'adds two numbers' do     expect(add(2, 3)).to eq(7)   end end</span>\n     <span style=\"color: red\"></span>\n     <span style=\"color: red\">  expected: 7</span>\n     <span style=\"color: red\">       got: 5</span>\n     <span style=\"color: red\"></span>\n     <span style=\"color: red\">  (compared using ==)</span>\n     <span style=\"color: cyan\"># /tmp/test.rb:11:in `block (2 levels) in <main>'</span>\n\nFinished in 0.00711 seconds (files took 0.04915 seconds to load)\n<span style=\"color: red\">1 example, 1 failure</span>\n\nFailed examples:\n\n<span style=\"color: red\">rspec /tmp/test.rb:11</span> <span style=\"color: cyan\"># addition adds two numbers</span>"
irb(main):022:0>
```